### PR TITLE
explicit cast NSUInteger (unsigned long) to int

### DIFF
--- a/iOS/src/GBYFetchedResultsController.m
+++ b/iOS/src/GBYFetchedResultsController.m
@@ -29,14 +29,14 @@
 
 - (int)sectionCount
 {
-    return self.sections.count;
+    return (int)self.sections.count; // unsigned long
 }
 
 - (int)numberOfObjectsInSection:(int)section
 {
     if (self.sectionCount) {
         id <NSFetchedResultsSectionInfo> sectionInfo = [self.sections objectAtIndex:section];
-        return [sectionInfo numberOfObjects];
+        return (int)[sectionInfo numberOfObjects]; // unsigned long
     }
     return 0;
 }


### PR DESCRIPTION
fix a warning in Xcode 6.1 for explicit conversion from NSUInteger
(which is equivalent of unsigned long) to JavaScript compatible int.
I’m guessing this would not commonly overflow since it is a count of
visible objects, so less than 2 billion
